### PR TITLE
powerline-daemon + mavericks = <3

### DIFF
--- a/powerline-client.c
+++ b/powerline-client.c
@@ -14,6 +14,7 @@
 
 #ifdef __APPLE__
 #include <string.h>
+#include <AvailabilityMacros.h>
 #endif
 
 #define handle_error(msg) \
@@ -72,7 +73,7 @@ int main(int argc, char *argv[]) {
     strncpy(server.sun_path+1, address, strlen(address));
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED < 1090
     if (connect(sd, (struct sockaddr *) &server, sizeof(server.sun_family) + strlen(address)) < 0) {
 #else
     if (connect(sd, (struct sockaddr *) &server, sizeof(server.sun_family) + strlen(address)+1) < 0) {

--- a/powerline-client.c
+++ b/powerline-client.c
@@ -12,6 +12,10 @@
 #include <unistd.h>
 #include <errno.h>
 
+#ifdef __APPLE__
+#include <string.h>
+#endif
+
 #define handle_error(msg) \
     do { perror(msg); exit(EXIT_FAILURE); } while (0)
 


### PR DESCRIPTION
In OS X 10.9 two things happened:

First I was getting compiler warnings -- including string.h fixed that.

Second, the client was super slow. After some debugging I found that the client wasn't connecting to the daemon and was always exec()ing powerline. Using the second (non **APPLE**) connect call turned out to be the right way to go, at least for 10.9. To gate it appropriately I changed the directive to only use the second connect on 10.9 and newer.
